### PR TITLE
Use `tail --pid` instead of a `sleep` loop

### DIFF
--- a/bakkes.sh
+++ b/bakkes.sh
@@ -44,6 +44,7 @@ if [ -f "$BAKKES" ]; then
     while ! killall -0 RocketLeague.exe 2> /dev/null && ! $SKIP_CHECKS; do
         sleep 1
     done
+    GAME_PID=$(ps cax | grep RocketLeague.exe | grep -Eo '^[0-9]+')
 
     # Open BakkesMod with the correct Proton version and Wine prefix
     # Doesn't require protontricks 
@@ -63,9 +64,7 @@ if [ -f "$BAKKES" ]; then
 
 
     # Kill BakkesMod process when Rocket League is closed
-    while killall -0 RocketLeague.exe 2> /dev/null && ! $SKIP_CHECKS; do
-        sleep 1
-    done
+    tail --pid=$GAME_PID -f /dev/null
 
     if ! $SKIP_CHECKS; then
         killall BakkesMod.exe

--- a/bakkes.sh
+++ b/bakkes.sh
@@ -41,10 +41,10 @@ if [ -f "$BAKKES" ]; then
     # Start BakkesMod when Rocket League starts
     # killall -0 sends no signal but still performs error checking
     # that way we can detect if a program is running or not
-    while ! killall -0 RocketLeague.exe 2> /dev/null && ! $SKIP_CHECKS; do
+    while ! pgrep RocketLeague 2> /dev/null && ! $SKIP_CHECKS; do
         sleep 1
     done
-    GAME_PID=$(ps cax | grep RocketLeague.exe | grep -Eo '^\s*[0-9]+\s' | xargs)
+    GAME_PID=$(pgrep RocketLeague)
 
     # Open BakkesMod with the correct Proton version and Wine prefix
     # Doesn't require protontricks 

--- a/bakkes.sh
+++ b/bakkes.sh
@@ -44,7 +44,7 @@ if [ -f "$BAKKES" ]; then
     while ! killall -0 RocketLeague.exe 2> /dev/null && ! $SKIP_CHECKS; do
         sleep 1
     done
-    GAME_PID=$(ps cax | grep RocketLeague.exe | grep -Eo '^[0-9]+')
+    GAME_PID=$(ps cax | grep RocketLeague.exe | grep -Eo '^\s*[0-9]+\s' | xargs)
 
     # Open BakkesMod with the correct Proton version and Wine prefix
     # Doesn't require protontricks 


### PR DESCRIPTION
The steam client seems to keep a journal of all the processes spawned from launching a game (presumably to be able to kill all processes associated with a game). I've noticed, that every time sleep is called, a new "sleep" process spawns, which is logged by the steam client. However, when the sleep process exits, steam does not seem to remove it from its journal. Considering one sleep process is spawned per second, long play sessions are likely to spam the journal with exorbitant amounts of data.

This commit uses `tail --pid` to wait for the game to exit. This is functionally equivalent to the sleep loop, but does not create 1 process per second.

The above explanation may be completely false, it is just an educated guess. However, I believe this change is a good change regardless, as it simplifies the script and doesn't have to do work in a loop.